### PR TITLE
Fix overflow in RankSupport::new if usize is not 64 bits

### DIFF
--- a/src/bit_vector/rank_support.rs
+++ b/src/bit_vector/rank_support.rs
@@ -80,7 +80,7 @@ impl RankSupport {
             let block_words = cmp::min(Self::WORDS_PER_BLOCK, words - block * Self::WORDS_PER_BLOCK);
             for word in 0..block_words {
                 block_ones += parent.data.word(block * Self::WORDS_PER_BLOCK + word).count_ones() as usize;
-                relative_ranks |= (block_ones << (word * Self::RELATIVE_RANK_BITS)) as u64;
+                relative_ranks |= ((block_ones as u64) << (word as u64 * Self::RELATIVE_RANK_BITS as u64)) as u64;
             }
             // Clear the high bit. We don't store the relative rank after all 8 words.
             relative_ranks &= bits::low_set((Self::WORDS_PER_BLOCK - 1) * Self::RELATIVE_RANK_BITS);


### PR DESCRIPTION
The left shift overflows easily if usize is not 64 bits, this fixes that.